### PR TITLE
fix: wrong link to Figma auth docs

### DIFF
--- a/packages/generate-icon-lib/src/services.ts
+++ b/packages/generate-icon-lib/src/services.ts
@@ -169,7 +169,7 @@ export async function getFigmaDocument(config: IFigmaConfig): Promise<IFigmaDocu
   if (data.status === 403 && data.err === 'Invalid token') {
     throw new CodedError(
       ERRORS.FIGMA_API,
-      'An invalid token was used. Follow the Auth Guide (https://git.io/fjBfF), and try again.'
+      'An invalid token was used. Follow the Auth Guide (https://git.io/Je87i), and try again.'
     );
   }
   return data.document;


### PR DESCRIPTION
The link provided when an error happens with the Figma auth (https://git.io/fjBfF) points to the radix monorepo where the icons used to live. This PR only changes the link to point to https://github.com/modulz/radix-icons/tree/master/packages/generate-icon-lib#authentication-with-figma